### PR TITLE
Check for mediatype before ID checks.

### DIFF
--- a/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrRestService.kt
@@ -46,6 +46,10 @@ class JellyseerrRestService(
     }
 
     private fun mediaMatches(item: LibraryItem, candidate: RequestResponse): Boolean {
+        // Check if the media type is the same before checking anything else
+        if (!mediaTypeMatches(item, candidate)) {
+            return false
+        }
 
         // Match between Radarr ID or Sonarr ID and the ID Jellyseerr stores for Radarr/Sonarr
         // TODO: Maybe grab the Jellyfin ID here to make deletion in Jellyfin easier down the line?
@@ -55,8 +59,8 @@ class JellyseerrRestService(
 
         // Fallback, match by meta data
         val imdbMatches = candidate.media.imdbId != null && (candidate.media.imdbId == item.imdbId)
-        val tmdbMatches = candidate.media.tmdbId != null && mediaTypeMatches(item, candidate) && (candidate.media.tmdbId == item.tmdbId)
-        val tvdbMatches = candidate.media.tvdbId != null && mediaTypeMatches(item, candidate) && (candidate.media.tvdbId == item.tvdbId)
+        val tmdbMatches = candidate.media.tmdbId != null && (candidate.media.tmdbId == item.tmdbId)
+        val tvdbMatches = candidate.media.tvdbId != null && (candidate.media.tvdbId == item.tvdbId)
         return imdbMatches || tmdbMatches || tvdbMatches
     }
 


### PR DESCRIPTION
Currently, some content is matching two requests for each item in jellyseer. This is because the IDs in sonar and radar are reused. 

```
2024-02-27T15:29:02.130239629Z 2024-02-27T07:29:02.130-08:00  INFO 1 --- [   scheduling-1] c.g.s.j.j.JellyseerrRestService          : Found request: RequestResponse(createdAt=2024-02-17T23:58:23.000Z, id=52, is4k=false, media=Media(createdAt=2024-02-17T23:58:23.000Z, id=52, requests=null, status=4, imdbId=null, tmdbId=52814, tvdbId=366524, externalServiceId=4, jellyfinMediaId=null, updatedAt=2024-02-18T12:30:00.000Z), modifiedBy=ModifiedBy(avatar=/os_logo_square.png, createdAt=2024-01-13T20:35:16.000Z, email=REDACTED, id=1, permissions=2, requestCount=60, updatedAt=2024-01-13T20:35:16.000Z, userType=3, displayName=REDACTED, username=null, plexUsername=null, jellyfinUsername=REDACTED), profileId=1, requestedBy=ModifiedBy(avatar=/os_logo_square.png, createdAt=2024-01-13T20:35:16.000Z, email=REDACTED, id=1, permissions=2, requestCount=60, updatedAt=2024-01-13T20:35:16.000Z, userType=3, displayName=REDACTED, username=null, plexUsername=null, jellyfinUsername=REDACTED), rootFolder=/downloads/tvshows, serverId=0, status=2, updatedAt=2024-02-17T23:58:23.000Z, seasons=[RequestSeason(createdAt=2024-02-17T23:58:23.000Z, id=4, seasonNumber=1, status=2, updatedAt=2024-02-17T23:58:23.000Z), RequestSeason(createdAt=2024-02-17T23:58:23.000Z, id=5, seasonNumber=2, status=2, updatedAt=2024-02-17T23:58:23.000Z)], type=tv) for /downloads/movies/Napoleon (2023)/Napoleon.2023.2160p.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-FLUX[TGx].mkv | IMDB: tt13287846
2024-02-27T15:29:02.130304454Z 2024-02-27T07:29:02.130-08:00  INFO 1 --- [   scheduling-1] c.g.s.j.j.JellyseerrRestService          : Found request: RequestResponse(createdAt=2024-01-14T21:58:05.000Z, id=3, is4k=false, media=Media(createdAt=2024-01-14T21:58:05.000Z, id=3, requests=null, status=5, imdbId=null, tmdbId=753342, tvdbId=null, externalServiceId=4, jellyfinMediaId=4003b8536864c6a9ff14c4121623d844, updatedAt=2024-02-25T11:00:04.000Z), modifiedBy=ModifiedBy(avatar=/os_logo_square.png, createdAt=2024-01-13T20:35:16.000Z, email=REDACTED, id=1, permissions=2, requestCount=60, updatedAt=2024-01-13T20:35:16.000Z, userType=3, displayName=REDACTED, username=null, plexUsername=null, jellyfinUsername=REDACTED), profileId=7, requestedBy=ModifiedBy(avatar=/os_logo_square.png, createdAt=2024-01-13T20:35:16.000Z, email=REDACTED, id=1, permissions=2, requestCount=60, updatedAt=2024-01-13T20:35:16.000Z, userType=3, displayName=REDACTED, username=null, plexUsername=null, jellyfinUsername=REDACTED), rootFolder=/downloads/movies, serverId=0, status=2, updatedAt=2024-01-14T21:58:05.000Z, seasons=[], type=movie) for /downloads/movies/Napoleon (2023)/Napoleon.2023.2160p.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-FLUX[TGx].mkv | IMDB: tt13287846
```

This change modifies the matching to check for a matching content type before performing any of the ID checks, which prevents returning the extra invalid matches. 