### PR TITLE
Switch to Spring Boot Native Image

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -47,3 +47,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build Native Image
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.5
+          arguments: bootBuildImage
+        env:
+          USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,7 +53,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 8.5
-          arguments: bootBuildImage
+          arguments: "bootBuildImage --publishImage"
         env:
           USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,6 +15,7 @@ on:
       - '**'
     branches:
       - 'develop'
+      - 'native'
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Build Native Image
         uses: gradle/actions/setup-gradle@v3
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           gradle-version: 8.5
           arguments: "bootBuildImage --publishImage"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,9 @@ import net.nemerosa.versioning.VersioningExtension
 import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.dsl.SpringBootExtension
+import org.springframework.boot.gradle.tasks.aot.ProcessAot
+import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
+import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
 
@@ -11,6 +14,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.4"
     id("com.google.cloud.tools.jib") version "3.4.0"
     id("net.nemerosa.versioning") version "2.8.2"
+    id("org.graalvm.buildtools.native") version "0.10.1"
 
     kotlin("jvm") version "1.9.22"
     kotlin("plugin.spring") version "1.9.22"
@@ -34,7 +38,7 @@ dependencies {
     implementation("io.github.openfeign:feign-jackson:13.1")
     implementation("io.github.openfeign:feign-httpclient:13.1")
 
-    developmentOnly("org.springframework.boot:spring-boot-devtools")
+    implementation("org.slf4j:jcl-over-slf4j")
 
     testImplementation(kotlin("test"))
     testImplementation("io.mockk:mockk:1.13.9")
@@ -62,6 +66,10 @@ kotlin {
     }
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
 tasks.withType<JavaCompile> {
     sourceCompatibility = JavaVersion.VERSION_21.toString()
     targetCompatibility = JavaVersion.VERSION_21.toString()
@@ -72,10 +80,6 @@ tasks.withType<KotlinCompile> {
         freeCompilerArgs = listOf("-Xjsr305=strict")
         jvmTarget = JavaVersion.VERSION_21.toString()
     }
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
 }
 
 configure<VersioningExtension> {
@@ -112,15 +116,43 @@ extra {
 
 }
 
+tasks.withType<BootRun> {
+    jvmArgs(
+        arrayOf(
+            "-Dspring.config.additional-location=optional:file:/config/application.yaml"
+        )
+    )
+}
+
+tasks.withType<ProcessAot> {
+    args("-Dspring.config.additional-location=optional:file:/config/application.yaml")
+}
+
+tasks.withType<BootBuildImage> {
+
+    docker.publishRegistry.url = "ghcr.io"
+    docker.publishRegistry.username = System.getenv("USERNAME") ?: "INVALID_USER"
+    docker.publishRegistry.password = System.getenv("GITHUB_TOKEN") ?: "INVALID_PASSWORD"
+    // docker.publishRegistry.token = System.getenv("GITHUB_TOKEN") ?: "INVALID_TOKEN"
+
+    imageName = "ghcr.io/${project.extra["docker.image.name"]}:${project.extra["docker.image.version"]}"
+    version = project.extra["docker.image.version"] as String
+    createdDate = "now"
+    tags = (project.extra["docker.image.tags"] as Set<String>).map { "ghcr.io/${project.extra["docker.image.name"]}:$it" }
+
+    tags.add("native")
+
+    // publish = true
+}
 
 jib {
     to {
-        image = "docker.io/${project.extra["docker.image.name"]}"
+        image = "ghcr.io/${project.extra["docker.image.name"]}"
         tags = project.extra["docker.image.tags"] as Set<String>
 
         auth {
-            username = System.getenv("DOCKERHUB_USER")
-            password = System.getenv("DOCKERHUB_PASSWORD")
+            username = System.getenv("USERNAME")
+            password = System.getenv("GITHUB_TOKEN")
         }
     }
     from {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,11 +138,11 @@ tasks.withType<BootBuildImage> {
     imageName = "ghcr.io/${project.extra["docker.image.name"]}:${project.extra["docker.image.version"]}"
     version = project.extra["docker.image.version"] as String
     createdDate = "now"
-    tags = (project.extra["docker.image.tags"] as Set<String>).map { "ghcr.io/${project.extra["docker.image.name"]}:$it" }
+    tags = listOf(
+            "ghcr.io/${project.extra["docker.image.name"]}:native",
+            "ghcr.io/${project.extra["docker.image.name"]}:native:${project.extra["docker.image.version"]}"
+    )
 
-    tags.add("ghcr.io/${project.extra["docker.image.name"]}:native")
-
-    // publish = true
 }
 
 jib {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,7 +173,7 @@ jib {
         }
     }
     container {
-        jvmFlags = listOf("-Dspring.config.additional-location=optional:file:/config/application.yaml", "-Xms512m")
+        jvmFlags = listOf("-Dspring.config.additional-location=optional:file:/config/application.yaml", "-Xms256m")
         mainClass = "com.github.schaka.janitorr.JanitorrApplicationKt"
         ports = listOf("8978")
         format = ImageFormat.Docker

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,7 +140,7 @@ tasks.withType<BootBuildImage> {
     createdDate = "now"
     tags = (project.extra["docker.image.tags"] as Set<String>).map { "ghcr.io/${project.extra["docker.image.name"]}:$it" }
 
-    tags.add("native")
+    tags.add("ghcr.io/${project.extra["docker.image.name"]}:native")
 
     // publish = true
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-group="com.github.schaka.janitorr"
+group=com.github.schaka.janitorr
 version=1.0.0b
-description="Cleans up your media library."
+description=Cleans up your media library.

--- a/src/main/kotlin/com/github/schaka/janitorr/JanitorrApplication.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/JanitorrApplication.kt
@@ -5,9 +5,7 @@ import com.github.schaka.janitorr.mediaserver.MediaServerClient
 import com.github.schaka.janitorr.mediaserver.MediaServerUserClient
 import com.github.schaka.janitorr.servarr.ServarrService
 import com.github.schaka.janitorr.servarr.radarr.RadarrClient
-import com.github.schaka.janitorr.servarr.radarr.RadarrRestService
 import com.github.schaka.janitorr.servarr.sonarr.SonarrClient
-import com.github.schaka.janitorr.servarr.sonarr.SonarrRestService
 import org.springframework.aot.hint.RuntimeHints
 import org.springframework.aot.hint.RuntimeHintsRegistrar
 import org.springframework.boot.autoconfigure.SpringBootApplication

--- a/src/main/kotlin/com/github/schaka/janitorr/JanitorrApplication.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/JanitorrApplication.kt
@@ -1,10 +1,21 @@
 package com.github.schaka.janitorr
 
+import com.github.schaka.janitorr.jellyseerr.JellyseerrClient
+import com.github.schaka.janitorr.mediaserver.MediaServerClient
+import com.github.schaka.janitorr.mediaserver.MediaServerUserClient
+import com.github.schaka.janitorr.servarr.ServarrService
+import com.github.schaka.janitorr.servarr.radarr.RadarrClient
+import com.github.schaka.janitorr.servarr.radarr.RadarrRestService
+import com.github.schaka.janitorr.servarr.sonarr.SonarrClient
+import com.github.schaka.janitorr.servarr.sonarr.SonarrRestService
+import org.springframework.aot.hint.RuntimeHints
+import org.springframework.aot.hint.RuntimeHintsRegistrar
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.ImportRuntimeHints
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
 
@@ -14,8 +25,22 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
-class JanitorrApplication
+@ImportRuntimeHints(JanitorrApplication.Hints::class)
+class JanitorrApplication {
+
+    class Hints : RuntimeHintsRegistrar {
+        override fun registerHints(hints: RuntimeHints, classLoader: ClassLoader?) {
+            hints.proxies().registerJdkProxy(JellyseerrClient::class.java)
+            hints.proxies().registerJdkProxy(MediaServerClient::class.java)
+            hints.proxies().registerJdkProxy(MediaServerUserClient::class.java)
+            hints.proxies().registerJdkProxy(RadarrClient::class.java)
+            hints.proxies().registerJdkProxy(SonarrClient::class.java)
+            hints.proxies().registerJdkProxy(ServarrService::class.java)
+        }
+    }
+}
 
 fun main(args: Array<String>) {
     runApplication<JanitorrApplication>(*args)
 }
+

--- a/src/main/kotlin/com/github/schaka/janitorr/config/ApplicationConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/config/ApplicationConfig.kt
@@ -1,0 +1,16 @@
+package com.github.schaka.janitorr.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(value = [ApplicationProperties::class])
+class ApplicationConfig {
+
+    @Bean
+    fun applicationProperties(applicationProperties: ApplicationProperties): ApplicationProperties {
+        return applicationProperties
+    }
+
+}

--- a/src/main/kotlin/com/github/schaka/janitorr/config/ApplicationProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/config/ApplicationProperties.kt
@@ -2,17 +2,15 @@ package com.github.schaka.janitorr.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.NestedConfigurationProperty
-import org.springframework.stereotype.Component
 import java.time.Duration
 
-@Component
 @ConfigurationProperties(prefix = "application")
 data class ApplicationProperties(
+        @NestedConfigurationProperty
+        val mediaDeletion: MediaDeletion,
+        @NestedConfigurationProperty
+        val tagBasedDeletion: TagDeletion,
         var dryRun: Boolean = false,
         var leavingSoon: Duration = Duration.ofDays(14),
-        @NestedConfigurationProperty
-        var mediaDeletion: MediaDeletion,
-        @NestedConfigurationProperty
-        var tagBasedDeletion: TagDeletion,
         var exclusionTag: String = "janitorr_keep"
 )

--- a/src/main/kotlin/com/github/schaka/janitorr/config/MediaDeletion.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/config/MediaDeletion.kt
@@ -1,9 +1,7 @@
 package com.github.schaka.janitorr.config
 
-import org.springframework.boot.context.properties.ConfigurationProperties
 import java.time.Duration
 
-@ConfigurationProperties
 data class MediaDeletion(
         var enabled: Boolean = true,
         var movieExpiration: Map<Int, Duration> = mapOf(

--- a/src/main/kotlin/com/github/schaka/janitorr/config/TagDeletion.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/config/TagDeletion.kt
@@ -1,8 +1,5 @@
 package com.github.schaka.janitorr.config
 
-import org.springframework.boot.context.properties.ConfigurationProperties
-
-@ConfigurationProperties
 data class TagDeletion(
         var enabled: Boolean = true,
         var minimumFreeDiskPercent: Double = 20.0,

--- a/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrClientConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrClientConfig.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders.CONTENT_TYPE
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 class JellyseerrClientConfig {
 
     companion object {
@@ -28,5 +28,4 @@ class JellyseerrClientConfig {
                 }
                 .target(JellyseerrClient::class.java, properties.url + "/api/v1")
     }
-
 }

--- a/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrConfig.kt
@@ -1,10 +1,17 @@
 package com.github.schaka.janitorr.jellyseerr
 
 import com.github.schaka.janitorr.config.ApplicationProperties
+import com.github.schaka.janitorr.jellyseerr.paging.JellyseerrPage
+import com.github.schaka.janitorr.jellyseerr.requests.ModifiedBy
+import com.github.schaka.janitorr.jellyseerr.requests.RequestResponse
+import com.github.schaka.janitorr.jellyseerr.requests.RequestSeason
+import com.github.schaka.janitorr.mediaserver.library.ExternalUrl
 import org.slf4j.LoggerFactory
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
+@RegisterReflectionForBinding(classes = [JellyseerrPage::class, RequestResponse::class, RequestSeason::class, ModifiedBy::class, ExternalUrl::class])
 @Configuration(proxyBeanMethods = false)
 class JellyseerrConfig(
     val jellyseerrClient: JellyseerrClient
@@ -16,7 +23,7 @@ class JellyseerrConfig(
 
     @Bean
     fun jellyseerrService(jellyseerrProperties: JellyseerrProperties, applicationProperties: ApplicationProperties): JellyseerrService {
-        return if(jellyseerrProperties.enabled) JellyseerrRestService(jellyseerrClient, applicationProperties) else JellyseerrNoOpService()
+        return if (jellyseerrProperties.enabled) JellyseerrRestService(jellyseerrClient, applicationProperties) else JellyseerrNoOpService()
     }
 
 }

--- a/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrConfig.kt
@@ -1,0 +1,22 @@
+package com.github.schaka.janitorr.jellyseerr
+
+import com.github.schaka.janitorr.config.ApplicationProperties
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class JellyseerrConfig(
+    val jellyseerrClient: JellyseerrClient
+) {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    @Bean
+    fun jellyseerrService(jellyseerrProperties: JellyseerrProperties, applicationProperties: ApplicationProperties): JellyseerrService {
+        return if(jellyseerrProperties.enabled) JellyseerrRestService(jellyseerrClient, applicationProperties) else JellyseerrNoOpService()
+    }
+
+}

--- a/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrNoOpService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrNoOpService.kt
@@ -2,14 +2,10 @@ package com.github.schaka.janitorr.jellyseerr
 
 import com.github.schaka.janitorr.servarr.LibraryItem
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.stereotype.Service
 
 /**
  * Does nothing. Used in case the user does not supply Jellyfin configuration.
  */
-@Service
-@ConditionalOnProperty("clients.jellyseerr.enabled", havingValue = "false", matchIfMissing = true)
 class JellyseerrNoOpService : JellyseerrService {
 
     companion object {

--- a/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrProperties.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "clients.jellyseerr")
 data class JellyseerrProperties(
+        val enabled: Boolean,
         val url: String,
         val apiKey: String
 )

--- a/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrRestService.kt
@@ -1,13 +1,10 @@
 package com.github.schaka.janitorr.jellyseerr
 
 import com.github.schaka.janitorr.config.ApplicationProperties
-import com.github.schaka.janitorr.jellyseerr.paging.JellyseerrPage
 import com.github.schaka.janitorr.jellyseerr.requests.RequestResponse
 import com.github.schaka.janitorr.servarr.LibraryItem
 import org.slf4j.LoggerFactory
-import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 
-@RegisterReflectionForBinding(classes = [JellyseerrPage::class, RequestResponse::class])
 class JellyseerrRestService(
 
         val jellyseerrClient: JellyseerrClient,

--- a/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/jellyseerr/JellyseerrRestService.kt
@@ -1,14 +1,13 @@
 package com.github.schaka.janitorr.jellyseerr
 
 import com.github.schaka.janitorr.config.ApplicationProperties
+import com.github.schaka.janitorr.jellyseerr.paging.JellyseerrPage
 import com.github.schaka.janitorr.jellyseerr.requests.RequestResponse
 import com.github.schaka.janitorr.servarr.LibraryItem
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.stereotype.Service
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 
-@Service
-@ConditionalOnProperty("clients.jellyseerr.enabled", havingValue = "true")
+@RegisterReflectionForBinding(classes = [JellyseerrPage::class, RequestResponse::class])
 class JellyseerrRestService(
 
         val jellyseerrClient: JellyseerrClient,

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/AbstractMediaServerRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/AbstractMediaServerRestService.kt
@@ -7,12 +7,8 @@ import com.github.schaka.janitorr.mediaserver.library.LibraryContent
 import com.github.schaka.janitorr.mediaserver.library.LibraryType
 import com.github.schaka.janitorr.mediaserver.library.LibraryType.MOVIES
 import com.github.schaka.janitorr.mediaserver.library.LibraryType.TV_SHOWS
-import com.github.schaka.janitorr.mediaserver.library.VirtualFolderResponse
-import com.github.schaka.janitorr.mediaserver.library.items.ItemPage
-import com.github.schaka.janitorr.mediaserver.library.items.MediaFolderItem
 import com.github.schaka.janitorr.servarr.LibraryItem
 import org.slf4j.LoggerFactory
-import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 import org.springframework.util.FileSystemUtils
 import java.nio.file.Files
 import java.nio.file.Path
@@ -21,7 +17,6 @@ import java.nio.file.Path
  * Keep 2 layers of abstract classes. The time is 100% going to come when Emby will split off from Jellyfin or the other way around.
  * By the point, it'll be much easier to refactor this.
  */
-@RegisterReflectionForBinding(classes = [ItemPage::class, MediaFolderItem::class, LibraryContent::class, VirtualFolderResponse::class])
 abstract class AbstractMediaServerRestService(
 
         val serviceName: String,

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/AbstractMediaServerRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/AbstractMediaServerRestService.kt
@@ -7,8 +7,12 @@ import com.github.schaka.janitorr.mediaserver.library.LibraryContent
 import com.github.schaka.janitorr.mediaserver.library.LibraryType
 import com.github.schaka.janitorr.mediaserver.library.LibraryType.MOVIES
 import com.github.schaka.janitorr.mediaserver.library.LibraryType.TV_SHOWS
+import com.github.schaka.janitorr.mediaserver.library.VirtualFolderResponse
+import com.github.schaka.janitorr.mediaserver.library.items.ItemPage
+import com.github.schaka.janitorr.mediaserver.library.items.MediaFolderItem
 import com.github.schaka.janitorr.servarr.LibraryItem
 import org.slf4j.LoggerFactory
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 import org.springframework.util.FileSystemUtils
 import java.nio.file.Files
 import java.nio.file.Path
@@ -17,6 +21,7 @@ import java.nio.file.Path
  * Keep 2 layers of abstract classes. The time is 100% going to come when Emby will split off from Jellyfin or the other way around.
  * By the point, it'll be much easier to refactor this.
  */
+@RegisterReflectionForBinding(classes = [ItemPage::class, MediaFolderItem::class, LibraryContent::class, VirtualFolderResponse::class])
 abstract class AbstractMediaServerRestService(
 
         val serviceName: String,

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/config/MediaServerConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/config/MediaServerConfig.kt
@@ -1,0 +1,50 @@
+package com.github.schaka.janitorr.mediaserver.config
+
+import com.github.schaka.janitorr.config.ApplicationProperties
+import com.github.schaka.janitorr.config.FileSystemProperties
+import com.github.schaka.janitorr.mediaserver.MediaServerClient
+import com.github.schaka.janitorr.mediaserver.MediaServerService
+import com.github.schaka.janitorr.mediaserver.MediaServerUserClient
+import com.github.schaka.janitorr.mediaserver.emby.Emby
+import com.github.schaka.janitorr.mediaserver.emby.EmbyProperties
+import com.github.schaka.janitorr.mediaserver.emby.EmbyRestService
+import com.github.schaka.janitorr.mediaserver.jellyfin.Jellyfin
+import com.github.schaka.janitorr.mediaserver.jellyfin.JellyfinProperties
+import com.github.schaka.janitorr.mediaserver.jellyfin.JellyfinRestService
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Only required for native image
+ */
+@Configuration(proxyBeanMethods = false)
+class MediaServerConfig(
+    @Emby val embyClient: MediaServerClient,
+    @Jellyfin val jellyfinClient: MediaServerClient,
+    @Emby val embyUserClient: MediaServerUserClient,
+    @Jellyfin val jellyfinUserClient: MediaServerUserClient,
+) {
+
+    @Bean
+    fun mediaServer(
+        jellyfinProperties: JellyfinProperties,
+        embyProperties: EmbyProperties,
+        applicationProperties: ApplicationProperties,
+        fileSystemProperties: FileSystemProperties
+    ): MediaServerService {
+
+        if (!jellyfinProperties.enabled && !embyProperties.enabled) {
+            return MediaServerNoOpService()
+        }
+
+        if (!jellyfinProperties.enabled && !embyProperties.enabled) {
+            throw IllegalStateException("Both Emby and Jellyfin CANNOT be enabled!")
+        }
+
+        if (embyProperties.enabled) {
+            return EmbyRestService(embyClient, embyUserClient, applicationProperties, fileSystemProperties)
+        }
+
+        return JellyfinRestService(jellyfinClient, jellyfinUserClient, applicationProperties, fileSystemProperties)
+    }
+}

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/config/MediaServerConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/config/MediaServerConfig.kt
@@ -11,12 +11,20 @@ import com.github.schaka.janitorr.mediaserver.emby.EmbyRestService
 import com.github.schaka.janitorr.mediaserver.jellyfin.Jellyfin
 import com.github.schaka.janitorr.mediaserver.jellyfin.JellyfinProperties
 import com.github.schaka.janitorr.mediaserver.jellyfin.JellyfinRestService
+import com.github.schaka.janitorr.mediaserver.library.LibraryContent
+import com.github.schaka.janitorr.mediaserver.library.ProviderIds
+import com.github.schaka.janitorr.mediaserver.library.UserData
+import com.github.schaka.janitorr.mediaserver.library.VirtualFolderResponse
+import com.github.schaka.janitorr.mediaserver.library.items.ItemPage
+import com.github.schaka.janitorr.mediaserver.library.items.MediaFolderItem
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 /**
  * Only required for native image
  */
+@RegisterReflectionForBinding(classes = [ItemPage::class, MediaFolderItem::class, LibraryContent::class, VirtualFolderResponse::class, ProviderIds::class, UserData::class])
 @Configuration(proxyBeanMethods = false)
 class MediaServerConfig(
     @Emby val embyClient: MediaServerClient,

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/config/MediaServerNoOpService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/config/MediaServerNoOpService.kt
@@ -1,16 +1,13 @@
-package com.github.schaka.janitorr.mediaserver
+package com.github.schaka.janitorr.mediaserver.config
 
+import com.github.schaka.janitorr.mediaserver.MediaServerService
 import com.github.schaka.janitorr.mediaserver.library.LibraryType
 import com.github.schaka.janitorr.servarr.LibraryItem
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.stereotype.Service
 
 /**
  * Does nothing. Used in case the user does not supply Jellyfin configuration.
  */
-@Service
-@ConditionalOnProperty(value = ["clients.emby.enabled", "clients.jellyfin.enabled"], havingValue = "false")
 class MediaServerNoOpService : MediaServerService() {
 
     companion object {

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyClientConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyClientConfig.kt
@@ -9,7 +9,6 @@ import feign.RequestTemplate
 import feign.jackson.JacksonDecoder
 import feign.jackson.JacksonEncoder
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpEntity
@@ -23,8 +22,7 @@ import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestTemplate
 import java.time.LocalDateTime
 
-@Configuration
-@ConditionalOnProperty("clients.emby.enabled", havingValue = "true")
+@Configuration(proxyBeanMethods = false)
 class EmbyClientConfig {
 
     companion object {

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyProperties.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "clients.emby")
 data class EmbyProperties(
+        val enabled: Boolean,
         val url: String,
         val apiKey: String,
         val username: String,

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyRestService.kt
@@ -5,12 +5,8 @@ import com.github.schaka.janitorr.config.FileSystemProperties
 import com.github.schaka.janitorr.mediaserver.AbstractMediaServerRestService
 import com.github.schaka.janitorr.mediaserver.MediaServerClient
 import com.github.schaka.janitorr.mediaserver.MediaServerUserClient
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.stereotype.Service
 
-@Service
-@ConditionalOnProperty("clients.emby.enabled", havingValue = "true", matchIfMissing = false)
-class EmbyRestService(
+open class EmbyRestService(
 
         @Emby embyClient: MediaServerClient,
         @Emby embyUserClient: MediaServerUserClient,

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinClientConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinClientConfig.kt
@@ -9,8 +9,6 @@ import feign.RequestTemplate
 import feign.jackson.JacksonDecoder
 import feign.jackson.JacksonEncoder
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.boot.web.client.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpEntity
@@ -22,22 +20,12 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
 import java.time.LocalDateTime
 
-@Configuration
-@ConditionalOnProperty("clients.jellyfin.enabled", havingValue = "true")
+@Configuration(proxyBeanMethods = false)
 class JellyfinClientConfig {
 
     companion object {
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private val janitorrClientString = "Client=\"Janitorr\", Device=\"Spring Boot\", DeviceId=\"Janitorr-Device-Id\", Version=\"1.0\""
-    }
-
-    @Jellyfin
-    @Bean
-    fun jellyfinRestTemplate(builder: RestTemplateBuilder, properties: JellyfinProperties): RestTemplate {
-        return builder
-                .rootUri("${properties.url}/")
-                .defaultHeader(AUTHORIZATION, "MediaBrowser Token=\"${properties.apiKey}\", $janitorrClientString")
-                .build()
     }
 
     @Jellyfin

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinProperties.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "clients.jellyfin")
 data class JellyfinProperties(
+        val enabled: Boolean,
         val url: String,
         val apiKey: String,
         val username: String,

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinRestService.kt
@@ -5,12 +5,8 @@ import com.github.schaka.janitorr.config.FileSystemProperties
 import com.github.schaka.janitorr.mediaserver.AbstractMediaServerRestService
 import com.github.schaka.janitorr.mediaserver.MediaServerClient
 import com.github.schaka.janitorr.mediaserver.MediaServerUserClient
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.stereotype.Service
 
-@Service
-@ConditionalOnProperty("clients.jellyfin.enabled", havingValue = "true", matchIfMissing = false)
-class JellyfinRestService(
+open class JellyfinRestService(
 
         @Jellyfin jellyfinClient: MediaServerClient,
         @Jellyfin jellyfinUserClient: MediaServerUserClient,

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/ServarrClientConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/ServarrClientConfig.kt
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders.CONTENT_TYPE
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 class ServarrClientConfig {
 
     companion object {

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/ServarrService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/ServarrService.kt
@@ -1,5 +1,7 @@
 package com.github.schaka.janitorr.servarr
 
+import jakarta.annotation.PostConstruct
+
 interface ServarrService {
 
     fun getEntries(): List<LibraryItem>
@@ -13,4 +15,5 @@ interface ServarrService {
         val comp = compareBy<LibraryItem> { it.date }
         return if (upgradesAllowed) comp.reversed() else comp
     }
+    fun postConstruct()
 }

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrConfig.kt
@@ -1,0 +1,38 @@
+package com.github.schaka.janitorr.servarr.radarr
+
+import com.github.schaka.janitorr.config.ApplicationProperties
+import com.github.schaka.janitorr.config.FileSystemProperties
+import com.github.schaka.janitorr.servarr.ServarrService
+import com.github.schaka.janitorr.servarr.data_structures.Tag
+import com.github.schaka.janitorr.servarr.history.HistoryResponse
+import com.github.schaka.janitorr.servarr.quality_profile.QualityProfile
+import com.github.schaka.janitorr.servarr.radarr.movie.MoviePayload
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Only required for native image
+ */
+@Configuration(proxyBeanMethods = false)
+@RegisterReflectionForBinding(classes = [QualityProfile::class, Tag::class, MoviePayload::class, HistoryResponse::class])
+class RadarrConfig(
+    val radarrNoOpService: RadarrNoOpService
+) {
+
+    @Bean
+    @Radarr
+    fun radarrService(
+        radarrProperties: RadarrProperties,
+        radarrClient: RadarrClient,
+        applicationProperties: ApplicationProperties,
+        fileSystemProperties: FileSystemProperties
+    ): ServarrService {
+        if (radarrProperties.enabled) {
+            val service = RadarrRestService(radarrClient, applicationProperties, fileSystemProperties)
+            service.postConstruct()
+            return service
+        }
+        return radarrNoOpService
+    }
+}

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrConfig.kt
@@ -15,8 +15,8 @@ import org.springframework.context.annotation.Configuration
  * Only required for native image
  */
 @Configuration(proxyBeanMethods = false)
-@RegisterReflectionForBinding(classes = [QualityProfile::class, Tag::class, MoviePayload::class, HistoryResponse::class])
 class RadarrConfig(
+    val radarrRestService: RadarrRestService,
     val radarrNoOpService: RadarrNoOpService
 ) {
 
@@ -28,11 +28,12 @@ class RadarrConfig(
         applicationProperties: ApplicationProperties,
         fileSystemProperties: FileSystemProperties
     ): ServarrService {
+
         if (radarrProperties.enabled) {
-            val service = RadarrRestService(radarrClient, applicationProperties, fileSystemProperties)
-            service.postConstruct()
-            return service
+            //return RadarrRestService(radarrClient, applicationProperties, fileSystemProperties, radarrProperties)
+            return radarrRestService
         }
+
         return radarrNoOpService
     }
 }

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrNoOpService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrNoOpService.kt
@@ -20,4 +20,8 @@ class RadarrNoOpService : ServarrService {
     override fun removeEntries(items: List<LibraryItem>) {
         log.info("Radarr is disabled, not deleting any movies")
     }
+
+    override fun postConstruct() {
+
+    }
 }

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrNoOpService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrNoOpService.kt
@@ -3,12 +3,9 @@ package com.github.schaka.janitorr.servarr.radarr
 import com.github.schaka.janitorr.servarr.LibraryItem
 import com.github.schaka.janitorr.servarr.ServarrService
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 
-@Radarr
 @Service
-@ConditionalOnProperty("clients.radarr.enabled", havingValue = "false", matchIfMissing = false)
 class RadarrNoOpService : ServarrService {
 
     companion object {

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrProperties.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "clients.radarr")
 data class RadarrProperties(
+        val enabled: Boolean,
         val url: String,
         val apiKey: String
 )

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrRestService.kt
@@ -5,19 +5,29 @@ import com.github.schaka.janitorr.config.FileSystemProperties
 import com.github.schaka.janitorr.servarr.LibraryItem
 import com.github.schaka.janitorr.servarr.ServarrService
 import com.github.schaka.janitorr.servarr.data_structures.Tag
+import com.github.schaka.janitorr.servarr.history.HistoryResponse
+import com.github.schaka.janitorr.servarr.quality_profile.QualityProfile
+import com.github.schaka.janitorr.servarr.radarr.movie.MoviePayload
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
 import java.nio.file.Path
 import java.time.LocalDateTime
 import kotlin.io.path.exists
 
-open class RadarrRestService(
+@RegisterReflectionForBinding(classes = [QualityProfile::class, Tag::class, MoviePayload::class, HistoryResponse::class])
+@Service
+class RadarrRestService(
 
         val radarrClient: RadarrClient,
 
         val applicationProperties: ApplicationProperties,
 
         val fileSystemProperties: FileSystemProperties,
+
+        val radarrProperties: RadarrProperties,
 
         var upgradesAllowed: Boolean = false,
 
@@ -31,7 +41,12 @@ open class RadarrRestService(
         const val CACHE_NAME = "radarr-cache"
     }
 
-    fun postConstruct() {
+    @PostConstruct
+    override fun postConstruct() {
+        if (!radarrProperties.enabled) {
+            return
+        }
+
         upgradesAllowed = radarrClient.getAllQualityProfiles().any { it.items.isNotEmpty() && it.upgradeAllowed }
         keepTag = radarrClient.getAllTags().firstOrNull { it.label == applicationProperties.exclusionTag } ?: keepTag
     }

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/radarr/RadarrRestService.kt
@@ -5,19 +5,13 @@ import com.github.schaka.janitorr.config.FileSystemProperties
 import com.github.schaka.janitorr.servarr.LibraryItem
 import com.github.schaka.janitorr.servarr.ServarrService
 import com.github.schaka.janitorr.servarr.data_structures.Tag
-import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.stereotype.Service
 import java.nio.file.Path
 import java.time.LocalDateTime
 import kotlin.io.path.exists
 
-@Radarr
-@Service
-@ConditionalOnProperty("clients.radarr.enabled", havingValue = "true", matchIfMissing = true)
-class RadarrService(
+open class RadarrRestService(
 
         val radarrClient: RadarrClient,
 
@@ -37,7 +31,6 @@ class RadarrService(
         const val CACHE_NAME = "radarr-cache"
     }
 
-    @PostConstruct
     fun postConstruct() {
         upgradesAllowed = radarrClient.getAllQualityProfiles().any { it.items.isNotEmpty() && it.upgradeAllowed }
         keepTag = radarrClient.getAllTags().firstOrNull { it.label == applicationProperties.exclusionTag } ?: keepTag

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrConfig.kt
@@ -1,0 +1,45 @@
+package com.github.schaka.janitorr.servarr.sonarr
+
+import com.github.schaka.janitorr.config.ApplicationProperties
+import com.github.schaka.janitorr.config.FileSystemProperties
+import com.github.schaka.janitorr.servarr.ServarrService
+import com.github.schaka.janitorr.servarr.data_structures.Tag
+import com.github.schaka.janitorr.servarr.history.HistoryResponse
+import com.github.schaka.janitorr.servarr.quality_profile.QualityProfile
+import com.github.schaka.janitorr.servarr.sonarr.series.SeriesPayload
+import org.slf4j.LoggerFactory
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Only required for native image
+ */
+@Configuration(proxyBeanMethods = false)
+@RegisterReflectionForBinding(classes = [QualityProfile::class, Tag::class, SeriesPayload::class, HistoryResponse::class])
+class SonarrConfig(
+    val sonarrNoOpService: SonarrNoOpService
+) {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    @Bean
+    @Sonarr
+    fun sonarrService(
+        sonarrProperties: SonarrProperties,
+        sonarrClient: SonarrClient,
+        filesystemProperties: FileSystemProperties,
+        applicationProperties: ApplicationProperties
+    ): ServarrService {
+
+        if (sonarrProperties.enabled) {
+            val service = SonarrRestService(sonarrClient, filesystemProperties, applicationProperties)
+            service.postConstruct()
+            return service
+        }
+
+        return sonarrNoOpService
+    }
+}

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrConfig.kt
@@ -6,6 +6,7 @@ import com.github.schaka.janitorr.servarr.ServarrService
 import com.github.schaka.janitorr.servarr.data_structures.Tag
 import com.github.schaka.janitorr.servarr.history.HistoryResponse
 import com.github.schaka.janitorr.servarr.quality_profile.QualityProfile
+import com.github.schaka.janitorr.servarr.sonarr.episodes.EpisodeResponse
 import com.github.schaka.janitorr.servarr.sonarr.series.SeriesPayload
 import org.slf4j.LoggerFactory
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
@@ -16,7 +17,7 @@ import org.springframework.context.annotation.Configuration
  * Only required for native image
  */
 @Configuration(proxyBeanMethods = false)
-@RegisterReflectionForBinding(classes = [QualityProfile::class, Tag::class, SeriesPayload::class, HistoryResponse::class])
+@RegisterReflectionForBinding(classes = [QualityProfile::class, Tag::class, SeriesPayload::class, HistoryResponse::class, EpisodeResponse::class])
 class SonarrConfig(
     val sonarrNoOpService: SonarrNoOpService
 ) {

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrConfig.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrConfig.kt
@@ -17,8 +17,8 @@ import org.springframework.context.annotation.Configuration
  * Only required for native image
  */
 @Configuration(proxyBeanMethods = false)
-@RegisterReflectionForBinding(classes = [QualityProfile::class, Tag::class, SeriesPayload::class, HistoryResponse::class, EpisodeResponse::class])
 class SonarrConfig(
+    val sonarrRestService: SonarrRestService,
     val sonarrNoOpService: SonarrNoOpService
 ) {
 
@@ -36,9 +36,8 @@ class SonarrConfig(
     ): ServarrService {
 
         if (sonarrProperties.enabled) {
-            val service = SonarrRestService(sonarrClient, filesystemProperties, applicationProperties)
-            service.postConstruct()
-            return service
+            return sonarrRestService
+            //return SonarrRestService(sonarrClient, filesystemProperties, applicationProperties, sonarrProperties)
         }
 
         return sonarrNoOpService

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrNoOpService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrNoOpService.kt
@@ -20,4 +20,7 @@ class SonarrNoOpService : ServarrService {
     override fun removeEntries(items: List<LibraryItem>) {
         log.info("Sonarr is disabled, not deleting any shows")
     }
+
+    override fun postConstruct() {
+    }
 }

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrNoOpService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrNoOpService.kt
@@ -3,12 +3,9 @@ package com.github.schaka.janitorr.servarr.sonarr
 import com.github.schaka.janitorr.servarr.LibraryItem
 import com.github.schaka.janitorr.servarr.ServarrService
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 
-@Sonarr
 @Service
-@ConditionalOnProperty("clients.sonarr.enabled", havingValue = "false", matchIfMissing = false)
 class SonarrNoOpService : ServarrService {
 
     companion object {

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrProperties.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "clients.sonarr")
 data class SonarrProperties(
+        val enabled: Boolean,
         val url: String,
         val apiKey: String
 )

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/SonarrRestService.kt
@@ -6,19 +6,13 @@ import com.github.schaka.janitorr.servarr.LibraryItem
 import com.github.schaka.janitorr.servarr.ServarrService
 import com.github.schaka.janitorr.servarr.data_structures.Tag
 import com.github.schaka.janitorr.servarr.sonarr.series.SeriesPayload
-import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.stereotype.Service
 import java.nio.file.Path
 import java.time.LocalDateTime
 import kotlin.io.path.exists
 
-@Sonarr
-@Service
-@ConditionalOnProperty("clients.sonarr.enabled", havingValue = "true", matchIfMissing = true)
-class SonarrService(
+open class SonarrRestService(
 
         val sonarrClient: SonarrClient,
 
@@ -37,7 +31,6 @@ class SonarrService(
         const val CACHE_NAME = "sonarr-cache"
     }
 
-    @PostConstruct
     fun postConstruct() {
         upgradesAllowed = sonarrClient.getAllQualityProfiles().any { it.items.isNotEmpty() && it.upgradeAllowed }
         keepTag = sonarrClient.getAllTags().firstOrNull { it.label == applicationProperties.exclusionTag } ?: keepTag

--- a/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/series/SeriesPayload.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/servarr/sonarr/series/SeriesPayload.kt
@@ -11,7 +11,7 @@ data class SeriesPayload(
         val seasonFolder: Boolean,
         val seasons: List<Season>,
         val seriesType: String,
-        val tags: List<Any>,
+        val tags: List<Int>,
         val title: String,
         val titleSlug: String,
         val tvMazeId: Int,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ clients:
     api-key: "sonarr-key"
   radarr:
     enabled: true
-    url: "http://htpc.local:7878"
+    url: "http://radarr:7878"
     api-key: "radarr-key"
   jellyfin:
     enabled: true


### PR DESCRIPTION
- without major rewrites
- proxies for major services still have to work (think caching)

- avoid having to declare annotations on classes they don't belong to (e.g. enabling reflection)
- if possible, not optional config overhead
- if possible keep NoOp implementations