### PR TITLE
[CI] Revert publishing user submitted images

### DIFF
--- a/.github/workflows/jvm-image.yml
+++ b/.github/workflows/jvm-image.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Run tests
         run: ./gradlew test
 
-
   build-jvm-x86:
     needs: [ run-test-suite ]
     runs-on: ubuntu-latest
@@ -105,8 +104,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5


### PR DESCRIPTION
It's a security risk anyway. Better to just save images in the future and have them published in a second, manual work flow triggered by the first workflow finishing