### PR TITLE
[Stats] Attempt optional fallback by season number

### DIFF
--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/AbstractMediaServerService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/AbstractMediaServerService.kt
@@ -6,6 +6,7 @@ import com.github.schaka.janitorr.mediaserver.filesystem.PathStructure
 import com.github.schaka.janitorr.mediaserver.library.LibraryContent
 import com.github.schaka.janitorr.mediaserver.library.LibraryType
 import com.github.schaka.janitorr.mediaserver.lookup.MediaLookup
+import com.github.schaka.janitorr.mediaserver.lookup.ResolvedMediaServerIds
 import com.github.schaka.janitorr.servarr.LibraryItem
 import org.slf4j.LoggerFactory
 import org.springframework.util.FileSystemUtils
@@ -36,6 +37,8 @@ abstract class AbstractMediaServerService {
     abstract fun updateLeavingSoon(cleanupType: CleanupType, libraryType: LibraryType, items: List<LibraryItem>, onlyAddLinks: Boolean = false)
 
     abstract fun getMediaServerIdsForLibrary(items: List<LibraryItem>, type: LibraryType, bySeason: Boolean ): Map<MediaLookup, List<String>>
+
+    abstract fun getMediaServerIdsForLibraryWithFallback(items: List<LibraryItem>, type: LibraryType, bySeason: Boolean): Map<MediaLookup, ResolvedMediaServerIds>
 
     abstract fun getAllFavoritedItems(): List<LibraryContent>
 

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/BaseMediaServerService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/BaseMediaServerService.kt
@@ -9,6 +9,7 @@ import com.github.schaka.janitorr.mediaserver.library.LibraryType.MOVIES
 import com.github.schaka.janitorr.mediaserver.library.LibraryType.TV_SHOWS
 import com.github.schaka.janitorr.mediaserver.library.VirtualFolderResponse
 import com.github.schaka.janitorr.mediaserver.lookup.MediaLookup
+import com.github.schaka.janitorr.mediaserver.lookup.ResolvedMediaServerIds
 import com.github.schaka.janitorr.servarr.LibraryItem
 import com.github.schaka.janitorr.servarr.bazarr.BazarrPayload
 import com.github.schaka.janitorr.servarr.bazarr.BazarrService
@@ -66,6 +67,13 @@ abstract class BaseMediaServerService(
         }
     }
 
+    override fun getMediaServerIdsForLibraryWithFallback(items: List<LibraryItem>, type: LibraryType, bySeason: Boolean): Map<MediaLookup, ResolvedMediaServerIds> {
+        return when (type) {
+            TV_SHOWS -> getMediaServerIdsForTvShowIdsWithFallback(items, bySeason)
+            MOVIES -> getMediaServerIdsForMovieIds(items).mapValues { (_, ids) -> ResolvedMediaServerIds(ids) }
+        }
+    }
+
     override fun cleanupTvShows(items: List<LibraryItem>) {
 
         if (!mediaServerProperties.delete) {
@@ -112,6 +120,28 @@ abstract class BaseMediaServerService(
                     mediaServerShows
                         .filter { tvShowMatches(show, it, bySeason) }
                         .map { it.Id }
+                }
+            }
+    }
+
+    private fun getMediaServerIdsForTvShowIdsWithFallback(items: List<LibraryItem>, bySeason: Boolean = true): Map<MediaLookup, ResolvedMediaServerIds> {
+        val mediaServerShows = getTvLibrary(bySeason)
+
+        return items
+            .groupBy { show -> lookup(bySeason, show) }
+            .mapValues { (_, showsInGroup) ->
+                val matchedContent = showsInGroup.flatMap { show ->
+                    mediaServerShows.filter { tvShowMatches(show, it, bySeason) }
+                }
+                val primaryIds = matchedContent.map { it.Id }
+
+                if (bySeason) {
+                    val fallbackIds = matchedContent
+                        .mapNotNull { it.SeriesId }
+                        .distinct()
+                    ResolvedMediaServerIds(primaryIds, fallbackIds)
+                } else {
+                    ResolvedMediaServerIds(primaryIds)
                 }
             }
     }

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/MediaServerLibraryQueryService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/MediaServerLibraryQueryService.kt
@@ -30,7 +30,10 @@ class MediaServerLibraryQueryService {
         if (bySeason) {
             mediaServerShows = mediaServerShows.flatMap { show ->
                 val seasons = mediaServerClient.getAllSeasons(show.Id).Items
-                seasons.forEach { it.ProviderIds = show.ProviderIds } // we want metadata (IMDB, TMDB) IDs for the entire show to match, not season IDs (only available from TVDB)
+                seasons.forEach {
+                    it.ProviderIds = show.ProviderIds // we want metadata (IMDB, TMDB) IDs for the entire show to match, not season IDs (only available from TVDB)
+                    it.SeriesId = it.SeriesId ?: show.Id // ensure SeriesId is always set for fallback lookups
+                }
                 return@flatMap seasons
             }
         }

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/config/MediaServerNoOpService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/config/MediaServerNoOpService.kt
@@ -5,6 +5,7 @@ import com.github.schaka.janitorr.mediaserver.AbstractMediaServerService
 import com.github.schaka.janitorr.mediaserver.library.LibraryContent
 import com.github.schaka.janitorr.mediaserver.library.LibraryType
 import com.github.schaka.janitorr.mediaserver.lookup.MediaLookup
+import com.github.schaka.janitorr.mediaserver.lookup.ResolvedMediaServerIds
 import com.github.schaka.janitorr.servarr.LibraryItem
 import org.slf4j.LoggerFactory
 
@@ -42,6 +43,15 @@ class MediaServerNoOpService : AbstractMediaServerService() {
         type: LibraryType,
         bySeason: Boolean
     ): Map<MediaLookup, List<String>> {
+        log.info("Media Server not implemented. No mediaServerIds populated.")
+        return mapOf()
+    }
+
+    override fun getMediaServerIdsForLibraryWithFallback(
+        items: List<LibraryItem>,
+        type: LibraryType,
+        bySeason: Boolean
+    ): Map<MediaLookup, ResolvedMediaServerIds> {
         log.info("Media Server not implemented. No mediaServerIds populated.")
         return mapOf()
     }

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/library/LibraryContent.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/library/LibraryContent.kt
@@ -11,6 +11,6 @@ data class LibraryContent(
         val SeasonId: String? = null,
         val SeasonName: String? = null,
         val IndexNumber: Int = 0,
-        val SeriesId: String? = null,
+        var SeriesId: String? = null,
         val SeriesName: String? = null,
 )

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/lookup/ResolvedMediaServerIds.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/lookup/ResolvedMediaServerIds.kt
@@ -1,0 +1,6 @@
+package com.github.schaka.janitorr.mediaserver.lookup
+
+data class ResolvedMediaServerIds(
+    val ids: List<String>,
+    val fallbackIds: List<String> = emptyList()
+)

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/jellystat/JellystatProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/jellystat/JellystatProperties.kt
@@ -9,4 +9,5 @@ data class JellystatProperties(
         override val url: String,
         override val wholeTvShow: Boolean = false,
         val apiKey: String,
+        val seasonFallback: Boolean = false,
 ) : StatsClientProperties

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/jellystat/JellystatRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/jellystat/JellystatRestService.kt
@@ -4,6 +4,7 @@ import com.github.schaka.janitorr.config.ApplicationProperties
 import com.github.schaka.janitorr.mediaserver.AbstractMediaServerService
 import com.github.schaka.janitorr.mediaserver.library.LibraryType
 import com.github.schaka.janitorr.mediaserver.lookup.MediaLookup
+import com.github.schaka.janitorr.mediaserver.lookup.ResolvedMediaServerIds
 import com.github.schaka.janitorr.servarr.LibraryItem
 import com.github.schaka.janitorr.stats.StatsService
 import com.github.schaka.janitorr.stats.jellystat.requests.JellyStatHistoryResponse
@@ -23,28 +24,35 @@ class JellystatRestService(
     }
 
     override fun populateWatchHistory(items: List<LibraryItem>, type: LibraryType) {
-
-        // TODO: if at all possible, we shouldn't populate the list of media server ids differently, but recognize a season and treat show as a whole as per application properties
-        // example: grab show id for season id, get WatchHistory based on show instead of season
         val bySeason = if (applicationProperties.wholeTvShow) false else !jellystatProperties.wholeTvShow
-        val libraryMappings = mediaServerService.getMediaServerIdsForLibrary(items, type, bySeason)
+        val libraryMappings = mediaServerService.getMediaServerIdsForLibraryWithFallback(items, type, bySeason)
 
         for (item in items) {
-            // every movie, show, season and episode has its own unique ID, so every request will only consider what's passed to it here
             val lookupKey = if (type == LibraryType.TV_SHOWS && bySeason) MediaLookup(item.id, item.season) else MediaLookup(item.id)
-            val watchHistory = libraryMappings.getOrDefault(lookupKey, listOf())
-                .map(::JellystatItemRequest)
-                .map(jellystatClient::getRequests)
-                .flatMap { page -> page.results }
-                .filter { it.PlaybackDuration > 60 }
-                .maxByOrNull { toDate(it.ActivityDateInserted) } // most recent date
+            val resolved = libraryMappings.getOrDefault(lookupKey, ResolvedMediaServerIds(emptyList()))
 
-            // only count view if at least one minute of content was watched - could be user adjustable later
+            var watchHistory = queryJellystat(resolved.ids)
+
+            if (watchHistory == null && resolved.fallbackIds.isNotEmpty()) {
+                log.debug("No watch history via season IDs for {} (season {}), falling back to show-level IDs", item.id, item.season)
+                watchHistory = queryJellystat(resolved.fallbackIds, seasonIdFilter = resolved.ids.toSet())
+            }
+
             if (watchHistory != null) {
                 item.lastSeen = toDate(watchHistory.ActivityDateInserted)
                 logWatchInfo(item, watchHistory)
             }
         }
+    }
+
+    private fun queryJellystat(jellyfinIds: List<String>, seasonIdFilter: Set<String>? = null): JellyStatHistoryResponse? {
+        return jellyfinIds
+            .map(::JellystatItemRequest)
+            .map(jellystatClient::getRequests)
+            .flatMap { page -> page.results }
+            .filter { it.PlaybackDuration > 60 }
+            .filter { seasonIdFilter == null || (it.SeasonId != null && it.SeasonId in seasonIdFilter) }
+            .maxByOrNull { toDate(it.ActivityDateInserted) }
     }
 
     private fun logWatchInfo(item: LibraryItem, watchHistory: JellyStatHistoryResponse?) {

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/jellystat/JellystatRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/jellystat/JellystatRestService.kt
@@ -35,7 +35,11 @@ class JellystatRestService(
 
             if (watchHistory == null && resolved.fallbackIds.isNotEmpty()) {
                 log.debug("No watch history via season IDs for {} (season {}), falling back to show-level IDs", item.id, item.season)
-                watchHistory = queryJellystat(resolved.fallbackIds, seasonIdFilter = resolved.ids.toSet())
+                watchHistory = if (jellystatProperties.seasonFallback) {
+                    queryJellystat(resolved.fallbackIds, seasonNumber = item.season)
+                } else {
+                    queryJellystat(resolved.fallbackIds, seasonIdFilter = resolved.ids.toSet())
+                }
             }
 
             if (watchHistory != null) {
@@ -45,13 +49,14 @@ class JellystatRestService(
         }
     }
 
-    private fun queryJellystat(jellyfinIds: List<String>, seasonIdFilter: Set<String>? = null): JellyStatHistoryResponse? {
+    private fun queryJellystat(jellyfinIds: List<String>, seasonIdFilter: Set<String>? = null, seasonNumber: Int? = null): JellyStatHistoryResponse? {
         return jellyfinIds
             .map(::JellystatItemRequest)
             .map(jellystatClient::getRequests)
             .flatMap { page -> page.results }
             .filter { it.PlaybackDuration > 60 }
             .filter { seasonIdFilter == null || (it.SeasonId != null && it.SeasonId in seasonIdFilter) }
+            .filter { seasonNumber == null || it.SeasonNumber == seasonNumber }
             .maxByOrNull { toDate(it.ActivityDateInserted) }
     }
 

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/jellystat/requests/JellyStatHistoryResponse.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/jellystat/requests/JellyStatHistoryResponse.kt
@@ -6,6 +6,7 @@ data class JellyStatHistoryResponse(
         val NowPlayingItemName: String?,
         val PlaybackDuration: Int, // Seconds
         val SeasonId: String?,
+        val SeasonNumber: Int?,
         val SeriesName: String?,
         val UserName: String?,
         val Client: String?,

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/StreamystatsProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/StreamystatsProperties.kt
@@ -9,4 +9,5 @@ data class StreamystatsProperties(
         override val url: String,
         override val wholeTvShow: Boolean = false,
         val apiKey: String,
+        val seasonFallback: Boolean = false,
 ) : StatsClientProperties

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/StreamystatsRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/StreamystatsRestService.kt
@@ -4,6 +4,7 @@ import com.github.schaka.janitorr.config.ApplicationProperties
 import com.github.schaka.janitorr.mediaserver.AbstractMediaServerService
 import com.github.schaka.janitorr.mediaserver.library.LibraryType
 import com.github.schaka.janitorr.mediaserver.lookup.MediaLookup
+import com.github.schaka.janitorr.mediaserver.lookup.ResolvedMediaServerIds
 import com.github.schaka.janitorr.servarr.LibraryItem
 import com.github.schaka.janitorr.stats.StatsService
 import com.github.schaka.janitorr.stats.streamystats.requests.StreamystatsHistoryResponse
@@ -24,30 +25,39 @@ class StreamystatsRestService(
     }
 
     override fun populateWatchHistory(items: List<LibraryItem>, type: LibraryType) {
-        // if WatchHistory settings require a different way of aggregating MediaServerIds, request them again
-        // TODO: if at all possible, we shouldn't populate the list of media server ids differently, but recognize a season and treat show as a whole as per application properties
-        // example: grab show id for season id, get WatchHistory based on show instead of season
         val bySeason = if (applicationProperties.wholeTvShow) false else !streamystatsProperties.wholeTvShow
-        val libraryMappings = mediaServerService.getMediaServerIdsForLibrary(items, type, bySeason)
+        val libraryMappings = mediaServerService.getMediaServerIdsForLibraryWithFallback(items, type, bySeason)
 
         for (item in items) {
-            // every movie, show, season and episode has its own unique ID, so every request will only consider what's passed to it here
             val lookupKey = if (type == LibraryType.TV_SHOWS && bySeason) MediaLookup(item.id, item.season) else MediaLookup(item.id)
-            val response = libraryMappings.getOrDefault(lookupKey, listOf())
-                .map(::gracefulQuery)
+            val resolved = libraryMappings.getOrDefault(lookupKey, ResolvedMediaServerIds(emptyList()))
 
-            val watchHistory = response
-                .filter { it != null && it.lastWatched != null }
-                .flatMap { it!!.watchHistory }
-                .filter { it.watchDuration > 60 }
-                .maxByOrNull { toDate(it.watchDate) } // most recent date
+            var (watchHistory, response) = queryStreamystats(resolved.ids)
 
-            // only count view if at least one minute of content was watched - could be user adjustable later
+            if (watchHistory == null && resolved.fallbackIds.isNotEmpty()) {
+                log.debug("No watch history via season IDs for {} (season {}), falling back to show-level IDs", item.id, item.season)
+                val (fallbackWatch, fallbackResponse) = queryStreamystats(resolved.fallbackIds, seasonIdFilter = resolved.ids.toSet())
+                watchHistory = fallbackWatch
+                response = fallbackResponse
+            }
+
             if (watchHistory != null) {
                 item.lastSeen = toDate(watchHistory.watchDate)
-                logWatchInfo(item, watchHistory, response[0])
+                logWatchInfo(item, watchHistory, response)
             }
         }
+    }
+
+    private fun queryStreamystats(jellyfinIds: List<String>, seasonIdFilter: Set<String>? = null): Pair<WatchHistoryEntry?, StreamystatsHistoryResponse?> {
+        val responses = jellyfinIds.mapNotNull(::gracefulQuery)
+            .filter { seasonIdFilter == null || (it.item.seasonId != null && it.item.seasonId in seasonIdFilter) }
+        val firstResponse = responses.firstOrNull()
+        val watchHistory = responses
+            .filter { it.lastWatched != null }
+            .flatMap { it.watchHistory }
+            .filter { it.watchDuration > 60 }
+            .maxByOrNull { toDate(it.watchDate) }
+        return watchHistory to firstResponse
     }
 
     private fun gracefulQuery(jellyfinId: String): StreamystatsHistoryResponse? {

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/StreamystatsRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/StreamystatsRestService.kt
@@ -34,10 +34,10 @@ class StreamystatsRestService(
 
             var (watchHistory, response) = queryStreamystats(resolved.ids)
 
-            if (watchHistory == null && resolved.fallbackIds.isNotEmpty()) {
+            if (bySeason && watchHistory == null && resolved.fallbackIds.isNotEmpty()) {
                 log.debug("No watch history via season IDs for {} (season {}), falling back to show-level IDs", item.id, item.season)
                 val (fallbackWatch, fallbackResponse) = if (streamystatsProperties.seasonFallback) {
-                    queryStreamystatsWithSeasonFallback(resolved.fallbackIds, item.season)
+                    queryStreamystatsWithSeasonFallback(resolved.fallbackIds, item.season!!)
                 } else {
                     queryStreamystats(resolved.fallbackIds, seasonIdFilter = resolved.ids.toSet())
                 }

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/StreamystatsRestService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/StreamystatsRestService.kt
@@ -36,7 +36,11 @@ class StreamystatsRestService(
 
             if (watchHistory == null && resolved.fallbackIds.isNotEmpty()) {
                 log.debug("No watch history via season IDs for {} (season {}), falling back to show-level IDs", item.id, item.season)
-                val (fallbackWatch, fallbackResponse) = queryStreamystats(resolved.fallbackIds, seasonIdFilter = resolved.ids.toSet())
+                val (fallbackWatch, fallbackResponse) = if (streamystatsProperties.seasonFallback) {
+                    queryStreamystatsWithSeasonFallback(resolved.fallbackIds, item.season)
+                } else {
+                    queryStreamystats(resolved.fallbackIds, seasonIdFilter = resolved.ids.toSet())
+                }
                 watchHistory = fallbackWatch
                 response = fallbackResponse
             }
@@ -58,6 +62,30 @@ class StreamystatsRestService(
             .filter { it.watchDuration > 60 }
             .maxByOrNull { toDate(it.watchDate) }
         return watchHistory to firstResponse
+    }
+
+    private fun queryStreamystatsWithSeasonFallback(showIds: List<String>, targetSeason: Int): Pair<WatchHistoryEntry?, StreamystatsHistoryResponse?> {
+        val showResponses = showIds.mapNotNull(::gracefulQuery)
+
+        val candidateSeasonIds = showResponses
+            .flatMap { it.watchHistory }
+            .mapNotNull { it.seasonId }
+            .distinct()
+
+        val matchingSeasonResponse = candidateSeasonIds
+            .mapNotNull(::gracefulQuery)
+            .firstOrNull { it.item.indexNumber == targetSeason }
+            ?: return null to null
+
+        val matchingSeasonId = matchingSeasonResponse.item.id
+
+        val watchEntry = showResponses
+            .filter { it.lastWatched != null }
+            .flatMap { it.watchHistory }
+            .filter { it.seasonId == matchingSeasonId && it.watchDuration > 60 }
+            .maxByOrNull { toDate(it.watchDate) }
+
+        return watchEntry to matchingSeasonResponse
     }
 
     private fun gracefulQuery(jellyfinId: String): StreamystatsHistoryResponse? {

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/requests/WatchHistoryEntry.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/requests/WatchHistoryEntry.kt
@@ -7,5 +7,6 @@ data class WatchHistoryEntry(
     val watchDate: String,
     val playMethod: String,
     val deviceName: String,
-    val clientName: String
+    val clientName: String,
+    val seasonId: String?,
 )

--- a/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/requests/WatchHistoryItem.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/stats/streamystats/requests/WatchHistoryItem.kt
@@ -10,4 +10,5 @@ data class WatchHistoryItem(
     val seasonId: String?,
     val seriesName: String?,
     val seasonName: String?,
+    val indexNumber: Int?,
 )

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -121,11 +121,13 @@ clients:
   jellystat: # Only one, Jellystat or Streamystats can be used
     enabled: true
     whole-tv-show: false # Enabling this will make Jellystat consider TV shows as a whole if any episode of any season has been watched
+    season-fallback: false # When enabled, falls back to matching by season number (instead of season UUID) when no watch history is found for a season - useful if seasons were re-imported and got new UUIDs
     url: "http://jellystat:3000"
     api-key: "jellystat-key"
 
   streamystats: # Only one, Streamystats or Jellystat can be used
     enabled: false
     whole-tv-show: false # Enabling this will make Streamystats consider TV shows as a whole if any episode of any season has been watched
+    season-fallback: false # When enabled, falls back to matching by season number (instead of season UUID) when no watch history is found for a season - requires additional API calls per unique season found in the show's watch history
     url: "http://streamystats:3000"
     api-key: "jellystat-key" # Jellyfin API key


### PR DESCRIPTION
This enables the user to allow a fallback option for Jellystat/Streamystats.

It falls back to per show lookup and attempts to match seasons manually by number in an attempt to circumvent wrong/brorken matching on the stats server side.