### PR TITLE
Add exclude-favorited-users allowlist to limit whose favorites protect media

### DIFF
--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/BaseMediaServerService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/BaseMediaServerService.kt
@@ -267,9 +267,11 @@ abstract class BaseMediaServerService(
             return emptyList()
         }
 
-        val users = filterAllowedUsers(mediaServerClient.listUsers())
+        val users = mediaServerClient.listUsers()
+        warnAboutUnmatchedAllowlistEntries(users)
 
-        return users.flatMap { user ->
+        return users.filter(::isAllowlistedForFavorites)
+            .flatMap { user ->
                 try {
                     mediaServerClient.getUserFavorites(user.Id).Items
                 } catch (e: Exception) {
@@ -280,22 +282,21 @@ abstract class BaseMediaServerService(
     }
 
     /**
-     * If exclude-favorited-users is set, only the favorites of those users (matched by name, case-insensitive, or by ID)
-     * are taken into account. An empty list means favorites from ALL users protect media from deletion.
+     * If exclude-favorited-allowlist is set, only the favorites of those users (matched by name, case-insensitive, or by ID)
+     * are taken into account. Leaving the allowlist out entirely (or empty) means favorites from ALL users protect media.
      */
-    private fun filterAllowedUsers(users: List<MediaServerUser>): List<MediaServerUser> {
-        val allowedUsers = mediaServerProperties.excludeFavoritedUsers
+    private fun isAllowlistedForFavorites(user: MediaServerUser): Boolean {
+        val allowlist = mediaServerProperties.excludeFavoritedAllowlist
+        return allowlist.isEmpty() || allowlist.any { user.matches(it) }
+    }
 
-        if (allowedUsers.isEmpty()) {
-            return users
-        }
+    private fun warnAboutUnmatchedAllowlistEntries(users: List<MediaServerUser>) {
+        val unmatched = mediaServerProperties.excludeFavoritedAllowlist
+            .filterNot { allowed -> users.any { it.matches(allowed) } }
 
-        val unmatched = allowedUsers.filterNot { allowed -> users.any { it.matches(allowed) } }
         if (unmatched.isNotEmpty()) {
-            log.warn("Some entries of exclude-favorited-users don't match any user on the media server: {}", unmatched)
+            log.warn("Some entries of exclude-favorited-allowlist don't match any user on the media server: {}", unmatched)
         }
-
-        return users.filter { user -> allowedUsers.any { user.matches(it) } }
     }
 
     private fun MediaServerUser.matches(nameOrId: String) = nameOrId.equals(Name, ignoreCase = true) || nameOrId == Id

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/BaseMediaServerService.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/BaseMediaServerService.kt
@@ -3,6 +3,7 @@ package com.github.schaka.janitorr.mediaserver
 import com.github.schaka.janitorr.cleanup.CleanupType
 import com.github.schaka.janitorr.config.ApplicationProperties
 import com.github.schaka.janitorr.config.FileSystemProperties
+import com.github.schaka.janitorr.mediaserver.api.MediaServerUser
 import com.github.schaka.janitorr.mediaserver.library.LibraryContent
 import com.github.schaka.janitorr.mediaserver.library.LibraryType
 import com.github.schaka.janitorr.mediaserver.library.LibraryType.MOVIES
@@ -266,7 +267,7 @@ abstract class BaseMediaServerService(
             return emptyList()
         }
 
-        val users = mediaServerClient.listUsers()
+        val users = filterAllowedUsers(mediaServerClient.listUsers())
 
         return users.flatMap { user ->
                 try {
@@ -277,6 +278,27 @@ abstract class BaseMediaServerService(
                 }
             }.distinctBy { it.Id }
     }
+
+    /**
+     * If exclude-favorited-users is set, only the favorites of those users (matched by name, case-insensitive, or by ID)
+     * are taken into account. An empty list means favorites from ALL users protect media from deletion.
+     */
+    private fun filterAllowedUsers(users: List<MediaServerUser>): List<MediaServerUser> {
+        val allowedUsers = mediaServerProperties.excludeFavoritedUsers
+
+        if (allowedUsers.isEmpty()) {
+            return users
+        }
+
+        val unmatched = allowedUsers.filterNot { allowed -> users.any { it.matches(allowed) } }
+        if (unmatched.isNotEmpty()) {
+            log.warn("Some entries of exclude-favorited-users don't match any user on the media server: {}", unmatched)
+        }
+
+        return users.filter { user -> allowedUsers.any { user.matches(it) } }
+    }
+
+    private fun MediaServerUser.matches(nameOrId: String) = nameOrId.equals(Name, ignoreCase = true) || nameOrId == Id
 
     override fun filterOutFavorites(items: List<LibraryItem>, libraryType: LibraryType): List<LibraryItem> {
         val favoritedItems = getAllFavoritedItems()

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/MediaServerProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/MediaServerProperties.kt
@@ -8,6 +8,7 @@ interface MediaServerProperties {
     val password: String
     val delete: Boolean
     val excludeFavorited: Boolean
+    val excludeFavoritedUsers: List<String>
     val leavingSoonTv: String
     val leavingSoonMovies: String
     val leavingSoonType: LeavingSoonType

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/MediaServerProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/MediaServerProperties.kt
@@ -8,7 +8,7 @@ interface MediaServerProperties {
     val password: String
     val delete: Boolean
     val excludeFavorited: Boolean
-    val excludeFavoritedUsers: List<String>
+    val excludeFavoritedAllowlist: List<String>
     val leavingSoonTv: String
     val leavingSoonMovies: String
     val leavingSoonType: LeavingSoonType

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyProperties.kt
@@ -14,6 +14,7 @@ data class EmbyProperties(
         override val password: String,
         override val delete: Boolean = true,
         override val excludeFavorited: Boolean = false,
+        override val excludeFavoritedUsers: List<String> = emptyList(),
         override val leavingSoonTv: String = "Shows (Deleted Soon)",
         override val leavingSoonMovies: String = "Movies (Deleted Soon)",
         override val leavingSoonType: LeavingSoonType = MOVIES_AND_TV

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/emby/EmbyProperties.kt
@@ -14,7 +14,7 @@ data class EmbyProperties(
         override val password: String,
         override val delete: Boolean = true,
         override val excludeFavorited: Boolean = false,
-        override val excludeFavoritedUsers: List<String> = emptyList(),
+        override val excludeFavoritedAllowlist: List<String> = emptyList(),
         override val leavingSoonTv: String = "Shows (Deleted Soon)",
         override val leavingSoonMovies: String = "Movies (Deleted Soon)",
         override val leavingSoonType: LeavingSoonType = MOVIES_AND_TV

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinProperties.kt
@@ -14,6 +14,7 @@ data class JellyfinProperties(
         override val password: String,
         override val delete: Boolean = true,
         override val excludeFavorited: Boolean = false,
+        override val excludeFavoritedUsers: List<String> = emptyList(),
         override val leavingSoonTv: String = "Shows (Deleted Soon)",
         override val leavingSoonMovies: String = "Movies (Deleted Soon)",
         override val leavingSoonType: LeavingSoonType = MOVIES_AND_TV

--- a/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinProperties.kt
+++ b/src/main/kotlin/com/github/schaka/janitorr/mediaserver/jellyfin/JellyfinProperties.kt
@@ -14,7 +14,7 @@ data class JellyfinProperties(
         override val password: String,
         override val delete: Boolean = true,
         override val excludeFavorited: Boolean = false,
-        override val excludeFavoritedUsers: List<String> = emptyList(),
+        override val excludeFavoritedAllowlist: List<String> = emptyList(),
         override val leavingSoonTv: String = "Shows (Deleted Soon)",
         override val leavingSoonMovies: String = "Movies (Deleted Soon)",
         override val leavingSoonType: LeavingSoonType = MOVIES_AND_TV

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -94,6 +94,7 @@ clients:
     password: janitorr
     delete: true # Jellyfin setup is required for JellyStat. However, if you don't want Janitorr to send delete requests to the Jellyfin API, disable it here
     exclude-favorited: false # When enabled, items favorited by any Jellyfin user will be excluded from deletion and won't appear in Leaving Soon
+    exclude-favorited-users: [] # Optional allowlist for exclude-favorited - when set, only favorites of these users (by name, case-insensitive, or by user ID) protect media. An empty list means favorites from ALL users count.
     leaving-soon-tv: "Shows (Leaving Soon)"
     leaving-soon-movies: "Movies (Leaving Soon)"
     leaving-soon-type: MOVIES_AND_TV # Other valid values are MOVIES, TV and NONE
@@ -108,6 +109,7 @@ clients:
     password: janitorr
     delete: true # Emby setup is required for JellyStat. However, if you don't want Janitorr to send delete requests to the Emby API, disable it here
     exclude-favorited: false # When enabled, items favorited by any Jellyfin user will be excluded from deletion and won't appear in Leaving Soon
+    exclude-favorited-users: [] # Optional allowlist for exclude-favorited - when set, only favorites of these users (by name, case-insensitive, or by user ID) protect media. An empty list means favorites from ALL users count.
     leaving-soon-tv: "Shows (Leaving Soon)"
     leaving-soon-movies: "Movies (Leaving Soon)"
     leaving-soon-type: MOVIES_AND_TV # Other valid values are MOVIES, TV and NONE

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -108,7 +108,7 @@ clients:
     username: Janitorr
     password: janitorr
     delete: true # Emby setup is required for JellyStat. However, if you don't want Janitorr to send delete requests to the Emby API, disable it here
-    exclude-favorited: false # When enabled, items favorited by any Jellyfin user will be excluded from deletion and won't appear in Leaving Soon
+    exclude-favorited: false # When enabled, items favorited by any Emby user will be excluded from deletion and won't appear in Leaving Soon
     exclude-favorited-users: [] # Optional allowlist for exclude-favorited - when set, only favorites of these users (by name, case-insensitive, or by user ID) protect media. An empty list means favorites from ALL users count.
     leaving-soon-tv: "Shows (Leaving Soon)"
     leaving-soon-movies: "Movies (Leaving Soon)"

--- a/src/main/resources/application-template.yml
+++ b/src/main/resources/application-template.yml
@@ -94,7 +94,11 @@ clients:
     password: janitorr
     delete: true # Jellyfin setup is required for JellyStat. However, if you don't want Janitorr to send delete requests to the Jellyfin API, disable it here
     exclude-favorited: false # When enabled, items favorited by any Jellyfin user will be excluded from deletion and won't appear in Leaving Soon
-    exclude-favorited-users: [] # Optional allowlist for exclude-favorited - when set, only favorites of these users (by name, case-insensitive, or by user ID) protect media. An empty list means favorites from ALL users count.
+    # Optional allowlist for exclude-favorited: when set, only favorites of the listed users protect media from deletion.
+    # Leave the key out entirely (or set an empty list) to honor favorites from ALL users.
+    # exclude-favorited-allowlist:
+    #   - Alice                              # matched by username, case-insensitive
+    #   - 81daa6ec4e8d4a1c91ec073bfa2b6a9e   # or by user ID
     leaving-soon-tv: "Shows (Leaving Soon)"
     leaving-soon-movies: "Movies (Leaving Soon)"
     leaving-soon-type: MOVIES_AND_TV # Other valid values are MOVIES, TV and NONE
@@ -109,7 +113,11 @@ clients:
     password: janitorr
     delete: true # Emby setup is required for JellyStat. However, if you don't want Janitorr to send delete requests to the Emby API, disable it here
     exclude-favorited: false # When enabled, items favorited by any Emby user will be excluded from deletion and won't appear in Leaving Soon
-    exclude-favorited-users: [] # Optional allowlist for exclude-favorited - when set, only favorites of these users (by name, case-insensitive, or by user ID) protect media. An empty list means favorites from ALL users count.
+    # Optional allowlist for exclude-favorited: when set, only favorites of the listed users protect media from deletion.
+    # Leave the key out entirely (or set an empty list) to honor favorites from ALL users.
+    # exclude-favorited-allowlist:
+    #   - Alice                              # matched by username, case-insensitive
+    #   - 81daa6ec4e8d4a1c91ec073bfa2b6a9e   # or by user ID
     leaving-soon-tv: "Shows (Leaving Soon)"
     leaving-soon-movies: "Movies (Leaving Soon)"
     leaving-soon-type: MOVIES_AND_TV # Other valid values are MOVIES, TV and NONE

--- a/src/test/kotlin/com/github/schaka/janitorr/mediaserver/FavoritesTest.kt
+++ b/src/test/kotlin/com/github/schaka/janitorr/mediaserver/FavoritesTest.kt
@@ -318,4 +318,30 @@ internal class FavoritesTest {
         assertEquals(1, result.size)
         assertEquals("movie-123", result[0].Id)
     }
+
+    @Test
+    fun `Unknown allow-listed entries don't prevent valid entries from matching`() {
+        every { jellyfinProperties.enabled } returns true
+        every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns listOf("GhostUser", "User2")
+
+        val user1 = MediaServerUser("User1", "user-id-1")
+        val user2 = MediaServerUser("User2", "user-id-2")
+        every { mediaServerClient.listUsers() } returns listOf(user1, user2)
+
+        val movie1 = mockk<LibraryContent>(relaxed = true) {
+            every { Id } returns "movie-123"
+        }
+        val movie3 = mockk<LibraryContent>(relaxed = true) {
+            every { Id } returns "movie-789"
+        }
+
+        every { mediaServerClient.getUserFavorites("user-id-1") } returns ItemPage(listOf(movie1), 0, 1)
+        every { mediaServerClient.getUserFavorites("user-id-2") } returns ItemPage(listOf(movie3), 0, 1)
+
+        val result = jellyfinRestService.getAllFavoritedItems()
+
+        assertEquals(1, result.size)
+        assertEquals("movie-789", result[0].Id)
+    }
 }

--- a/src/test/kotlin/com/github/schaka/janitorr/mediaserver/FavoritesTest.kt
+++ b/src/test/kotlin/com/github/schaka/janitorr/mediaserver/FavoritesTest.kt
@@ -60,7 +60,7 @@ internal class FavoritesTest {
     fun `No favorites are returned when media server is disabled`() {
         every { jellyfinProperties.enabled } returns false
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns emptyList()
 
         val result = jellyfinRestService.getAllFavoritedItems()
 
@@ -71,7 +71,7 @@ internal class FavoritesTest {
     fun `Favorites are correctly aggregated across multiple users`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         val user2 = MediaServerUser("User2", "user-id-2")
@@ -109,7 +109,7 @@ internal class FavoritesTest {
     fun `Graceful failure per user is guaranteed`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         val user2 = MediaServerUser("User2", "user-id-2")
@@ -134,7 +134,7 @@ internal class FavoritesTest {
     fun `No favorites are returned if none are available at the server`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns emptyList()
         every { mediaServerClient.listUsers() } returns emptyList()
 
         val result = jellyfinRestService.getAllFavoritedItems()
@@ -157,7 +157,7 @@ internal class FavoritesTest {
 
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         every { mediaServerClient.listUsers() } returns listOf(user1)
@@ -199,7 +199,7 @@ internal class FavoritesTest {
 
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         every { mediaServerClient.listUsers() } returns listOf(user1)
@@ -241,7 +241,7 @@ internal class FavoritesTest {
 
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         every { mediaServerClient.listUsers() } returns listOf(user1)
@@ -271,7 +271,7 @@ internal class FavoritesTest {
     fun `Only favorites of allow-listed users are considered`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns listOf("USER2") // matching is case-insensitive
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns listOf("USER2") // matching is case-insensitive
 
         val user1 = MediaServerUser("User1", "user-id-1")
         val user2 = MediaServerUser("User2", "user-id-2")
@@ -297,7 +297,7 @@ internal class FavoritesTest {
     fun `Allow-listed users can also be matched by their ID`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns listOf("user-id-1")
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns listOf("user-id-1")
 
         val user1 = MediaServerUser("User1", "user-id-1")
         val user2 = MediaServerUser("User2", "user-id-2")
@@ -323,7 +323,7 @@ internal class FavoritesTest {
     fun `Unknown allow-listed entries don't prevent valid entries from matching`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
-        every { jellyfinProperties.excludeFavoritedUsers } returns listOf("GhostUser", "User2")
+        every { jellyfinProperties.excludeFavoritedAllowlist } returns listOf("GhostUser", "User2")
 
         val user1 = MediaServerUser("User1", "user-id-1")
         val user2 = MediaServerUser("User2", "user-id-2")

--- a/src/test/kotlin/com/github/schaka/janitorr/mediaserver/FavoritesTest.kt
+++ b/src/test/kotlin/com/github/schaka/janitorr/mediaserver/FavoritesTest.kt
@@ -60,6 +60,7 @@ internal class FavoritesTest {
     fun `No favorites are returned when media server is disabled`() {
         every { jellyfinProperties.enabled } returns false
         every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
 
         val result = jellyfinRestService.getAllFavoritedItems()
 
@@ -70,6 +71,7 @@ internal class FavoritesTest {
     fun `Favorites are correctly aggregated across multiple users`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         val user2 = MediaServerUser("User2", "user-id-2")
@@ -107,6 +109,7 @@ internal class FavoritesTest {
     fun `Graceful failure per user is guaranteed`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         val user2 = MediaServerUser("User2", "user-id-2")
@@ -131,6 +134,7 @@ internal class FavoritesTest {
     fun `No favorites are returned if none are available at the server`() {
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
         every { mediaServerClient.listUsers() } returns emptyList()
 
         val result = jellyfinRestService.getAllFavoritedItems()
@@ -153,6 +157,7 @@ internal class FavoritesTest {
 
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         every { mediaServerClient.listUsers() } returns listOf(user1)
@@ -194,6 +199,7 @@ internal class FavoritesTest {
 
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         every { mediaServerClient.listUsers() } returns listOf(user1)
@@ -235,6 +241,7 @@ internal class FavoritesTest {
 
         every { jellyfinProperties.enabled } returns true
         every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns emptyList()
 
         val user1 = MediaServerUser("User1", "user-id-1")
         every { mediaServerClient.listUsers() } returns listOf(user1)
@@ -258,5 +265,57 @@ internal class FavoritesTest {
         val result = jellyfinRestService.filterOutFavorites(listOf(item), LibraryType.TV_SHOWS)
 
         assertEquals(listOf(), result)
+    }
+
+    @Test
+    fun `Only favorites of allow-listed users are considered`() {
+        every { jellyfinProperties.enabled } returns true
+        every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns listOf("USER2") // matching is case-insensitive
+
+        val user1 = MediaServerUser("User1", "user-id-1")
+        val user2 = MediaServerUser("User2", "user-id-2")
+        every { mediaServerClient.listUsers() } returns listOf(user1, user2)
+
+        val movie1 = mockk<LibraryContent>(relaxed = true) {
+            every { Id } returns "movie-123"
+        }
+        val movie3 = mockk<LibraryContent>(relaxed = true) {
+            every { Id } returns "movie-789"
+        }
+
+        every { mediaServerClient.getUserFavorites("user-id-1") } returns ItemPage(listOf(movie1), 0, 1)
+        every { mediaServerClient.getUserFavorites("user-id-2") } returns ItemPage(listOf(movie3), 0, 1)
+
+        val result = jellyfinRestService.getAllFavoritedItems()
+
+        assertEquals(1, result.size)
+        assertEquals("movie-789", result[0].Id)
+    }
+
+    @Test
+    fun `Allow-listed users can also be matched by their ID`() {
+        every { jellyfinProperties.enabled } returns true
+        every { jellyfinProperties.excludeFavorited } returns true
+        every { jellyfinProperties.excludeFavoritedUsers } returns listOf("user-id-1")
+
+        val user1 = MediaServerUser("User1", "user-id-1")
+        val user2 = MediaServerUser("User2", "user-id-2")
+        every { mediaServerClient.listUsers() } returns listOf(user1, user2)
+
+        val movie1 = mockk<LibraryContent>(relaxed = true) {
+            every { Id } returns "movie-123"
+        }
+        val movie3 = mockk<LibraryContent>(relaxed = true) {
+            every { Id } returns "movie-789"
+        }
+
+        every { mediaServerClient.getUserFavorites("user-id-1") } returns ItemPage(listOf(movie1), 0, 1)
+        every { mediaServerClient.getUserFavorites("user-id-2") } returns ItemPage(listOf(movie3), 0, 1)
+
+        val result = jellyfinRestService.getAllFavoritedItems()
+
+        assertEquals(1, result.size)
+        assertEquals("movie-123", result[0].Id)
     }
 }


### PR DESCRIPTION
## Motivation

`exclude-favorited` currently aggregates favorites from **all** media server users. On instances shared with many users (29 in my case), any single user can permanently shield media from cleanup by favoriting it, with no way for the admin to control who has that privilege. (Related: #193, #69)

## What this PR does

Adds an optional `exclude-favorited-users` list to the `jellyfin` and `emby` client configs:

```yaml
exclude-favorited: true
exclude-favorited-users: # optional - empty/absent = current behavior (all users)
  - Alice          # matched by name, case-insensitive
  - user-id-hex    # or by user ID
```

- Empty or absent list -> behavior unchanged, fully backward compatible
- When set, only favorites of the listed users protect media from deletion
- Entries matching no user on the server log a warning (typo safety)

## Implementation

- New `excludeFavoritedUsers` on `MediaServerProperties` (+ Jellyfin/Emby properties, default empty)
- User filtering in `BaseMediaServerService.getAllFavoritedItems()` (shared by Jellyfin & Emby)
- `application-template.yml` documented for both servers
- Tests: existing `FavoritesTest` cases updated + 2 new cases (match by name, match by ID)

Note: `MediaCleanupScheduleTest > Duration is default when offset is disabled` fails on my machine on unmodified `main` as well — it reads the real free space of the disk running the tests (`freeSpaceCheckDir = "/"`).
